### PR TITLE
Normalize asset loading paths

### DIFF
--- a/src/Battleground.cpp
+++ b/src/Battleground.cpp
@@ -2,14 +2,15 @@
 #include <SFML/Graphics/Sprite.hpp>
 #include <SFML/Graphics/Texture.hpp>
 #include <SFML/Graphics/RenderWindow.hpp>
+#include "Assets.h"
 using namespace std;
 using namespace sf;
 
 Battleground::Battleground(string battleground_name) {//recibe un string con el nombre del mapa requerido
-	battleground_textura.loadFromFile(battleground_name);
+	battleground_textura.loadFromFile(asset("backgrounds/" + battleground_name));
 	battleground_sprite.setTexture(battleground_textura);
 	battleground_sprite.setPosition(0, 0);
-	music.openFromFile("Battleground_music_0.wav");
+	music.openFromFile(asset("audio/music/Battleground_music_0.wav"));
 	music.setVolume(25);
 }
 

--- a/src/Efectos_de_sonido_menus.cpp
+++ b/src/Efectos_de_sonido_menus.cpp
@@ -1,19 +1,20 @@
 #include "Efectos_de_sonido_menus.h"
+#include "Assets.h"
 
 using namespace std;
 using namespace sf;
 
 Efectos_de_sonido_menus::Efectos_de_sonido_menus() {
-	moving_effect_soundbuffer.loadFromFile("audio/sfx/Menu_moving_effect.wav");
+	moving_effect_soundbuffer.loadFromFile(asset("audio/music/Menu_moving_effect.wav"));
 	moving_effect_sound.setBuffer(moving_effect_soundbuffer);
-	intro_effect_soundbuffer.loadFromFile("audio/sfx/Menu_Intro_Effect.wav");
+	intro_effect_soundbuffer.loadFromFile(asset("audio/music/Menu_Intro_Effect.wav"));
 	intro_effect_sound.setBuffer(intro_effect_soundbuffer);
 	
 	
 }
 
 void Efectos_de_sonido_menus::play_music(int i){
-	music.openFromFile("audio/music/Menu_music_"+to_string(i)+".wav");
+	music.openFromFile(asset("audio/music/Menu_music_"+to_string(i)+".wav"));
 	music.play();
 }
 

--- a/src/Fighting_Escena.cpp
+++ b/src/Fighting_Escena.cpp
@@ -8,6 +8,7 @@
 #include "Escena.h"
 #include <iostream>
 #include "Round.h"
+#include "Assets.h"
 using namespace std;
 
 Fighting_Escena::Fighting_Escena(){
@@ -17,7 +18,7 @@ Fighting_Escena::Fighting_Escena(){
 	menu=new Menu_Pause();
 	
 	//Cartel "Esc to Pause"
-	m_font.loadFromFile("MKtitle1.ttf");
+        m_font.loadFromFile(asset("fonts/MKtitle1.ttf"));
 	Escape_Text.setFont(m_font);
 	Escape_Text.setPosition(30,1020);
 	Escape_Text.setCharacterSize(30);

--- a/src/Healt_Bar.cpp
+++ b/src/Healt_Bar.cpp
@@ -3,6 +3,7 @@
 #include <SFML/Graphics/Sprite.hpp>
 #include <SFML/Graphics/RenderWindow.hpp>
 #include <SFML/System/Clock.hpp>
+#include "Assets.h"
 
 
 #include <iostream>
@@ -14,18 +15,18 @@ using namespace sf;
 Healt_Bar::Healt_Bar(int p1, int p2) {
 	//Inicializacion de texturas y sprites correspondientes a las barras de vida
 	for(int i=0;i<2;i++) {  
-	Healt_Bar_Texture[i].loadFromFile("health_bar_"+to_string(i)+".png");
+        Healt_Bar_Texture[i].loadFromFile(asset("sprites/health_bar_"+to_string(i)+".png"));
 	Healt_Bar_Player_1_Sprite[i].setTexture(Healt_Bar_Texture[i]);
 	Healt_Bar_Player_2_Sprite[i].setTexture(Healt_Bar_Texture[i]);
 	};
 	
 	//Inicializacion de texturas, sprites y textos correspondientes al reloj
-	clock_background_texture.loadFromFile("Life_bar_clock_background.png");
+        clock_background_texture.loadFromFile(asset("sprites/Life_bar_clock_background.png"));
 	clock_background_sprite.setTexture(clock_background_texture);
 	clock_background_sprite.setOrigin(27,26);
 	clock_background_sprite.setScale(2,2);
 	clock_background_sprite.setPosition(950,110);
-	text_font.loadFromFile("MKtitle1.ttf");
+        text_font.loadFromFile(asset("fonts/MKtitle1.ttf"));
 	clock_text.setFont(text_font);
 	clock_text.setCharacterSize(40);
 	clock_text.setPosition(925,80);

--- a/src/Kratos.cpp
+++ b/src/Kratos.cpp
@@ -9,18 +9,19 @@
 #include "Controles_Player_1.h"
 #include <SFML/System/Clock.hpp>
 #include <iostream>
+#include "Assets.h"
 using namespace std;
 using namespace sf;
 
-
-Kratos::Kratos(int player_1_o_2):Personaje_1_escena_fighting(player_1_o_2,"Kratos") {//Recibe una variable que le indica si es Player 1 o Player 2
+// TODO: Renombrar los sprites de Kratos a "Kratos_*" para alinear el casing con el resto.
+Kratos::Kratos(int player_1_o_2):Personaje_1_escena_fighting(player_1_o_2,"kratos") {//Recibe una variable que le indica si es Player 1 o Player 2
 
 //Efectos de sonido correspondientes al luchador
-	attacking_effect_soundbuffer.loadFromFile("Kratos_attack_sound_effect.wav");
+        attacking_effect_soundbuffer.loadFromFile(asset("audio/music/Kratos_attack_sound_effect.wav"));
 	attacking_effect_sound.setBuffer(attacking_effect_soundbuffer);
-	jumping_effect_soundbuffer.loadFromFile("Kratos_jumping_sound_effect.wav");
+        jumping_effect_soundbuffer.loadFromFile(asset("audio/music/Kratos_jumping_sound_effect.wav"));
 	jumping_effect_sound.setBuffer(jumping_effect_soundbuffer);
-	get_hit_effect_soundbuffer.loadFromFile("Kratos_get_hit_sound_effect.wav");
+        get_hit_effect_soundbuffer.loadFromFile(asset("audio/music/Kratos_get_hit_sound_effect.wav"));
 	get_hit_effect_sound.setBuffer(get_hit_effect_soundbuffer);
 
 	

--- a/src/Menu_Controls.cpp
+++ b/src/Menu_Controls.cpp
@@ -8,6 +8,7 @@
 #include <fstream>
 #include <SFML/System/Vector2.hpp>
 #include <string>
+#include "Assets.h"
 using namespace std;
 
 
@@ -28,17 +29,17 @@ Menu_Controls::Menu_Controls():pos_attack_text_p1(612,274),pos_jump_text_p1(614,
 	
 	
 	for(int i=0;i<10;i++) { 
-		menu_textura[i].loadFromFile("Menu_Controls_Sprite_"+to_string(i)+".png");
+		menu_textura[i].loadFromFile(asset("sprites/Menu_Controls_Sprite_"+to_string(i)+".png"));
 		menu_sprite[i].setTexture(menu_textura[i]);
 	}
 	InfoJugadores Info_J;
 	
 	
-	menu_background_textura.loadFromFile("Menu_Controls_Background.jpg");
+	menu_background_textura.loadFromFile(asset("backgrounds/Menu_Controls_Background.jpg"));
 	menu_background_sprite.setTexture(menu_background_textura);
 	
 	
-	m_font.loadFromFile("MKtitle1.ttf");
+	m_font.loadFromFile(asset("fonts/MKtitle1.ttf"));
 	text_nombre_player_1.setFont(m_font);
 	text_nombre_player_1.setPosition(37,72);
 	text_nombre_player_1.setCharacterSize(100);
@@ -297,7 +298,7 @@ void Menu_Controls::m_Setear_Nombre_Teclas_En_Pantalla(Vector2f posicion, Keyboa
 void Menu_Controls::m_CentrarTexto(Text &texto, Vector2f punto) {
 
 
-	// Obtiene el tamaño del texto
+	// Obtiene el tamao del texto
 	FloatRect bounds = texto.getLocalBounds();
 	
 	
@@ -311,20 +312,20 @@ void Menu_Controls::m_CentrarTexto(Text &texto, Vector2f punto) {
 }
 
 void Menu_Controls::m_Ajustar_Tamano_Texto(Text &texto) {
-	// Define el tamaño máximo y mínimo del texto
+	// Define el tamao mximo y mnimo del texto
 	int tamanoMaximo = 80;
 	int tamanoMinimo = 35;
 	
 	// Obtiene la longitud del texto actual
 	int longitud = texto.getString().getSize();
 	
-	// Calcula el nuevo tamaño del texto basado en la longitud
+	// Calcula el nuevo tamao del texto basado en la longitud
 	int nuevoTamano = tamanoMaximo - longitud*7;
 	
-	// Limita el tamaño del texto entre el máximo y el mínimo
+	// Limita el tamao del texto entre el mximo y el mnimo
 	nuevoTamano = max(tamanoMinimo, min(tamanoMaximo, nuevoTamano));
 	
-	// Establece el nuevo tamaño del texto
+	// Establece el nuevo tamao del texto
 	texto.setCharacterSize(nuevoTamano);
 }
 
@@ -378,7 +379,7 @@ string Menu_Controls:: m_Convertidor_Key_String(Keyboard::Key k) {
 	case Keyboard::Key::RShift: s = "Shift der"; break;
 	case Keyboard::Key::RAlt: s = "Alt der"; break;
 	case Keyboard::Key::RSystem: s = "Sist der"; break;
-	case Keyboard::Key::Menu: s = "Menú"; break;
+	case Keyboard::Key::Menu: s = "Men"; break;
 	case Keyboard::Key::LBracket: s = "["; break;
 	case Keyboard::Key::RBracket: s = "]"; break;
 	case Keyboard::Key::SemiColon: s = ";"; break;
@@ -394,8 +395,8 @@ string Menu_Controls:: m_Convertidor_Key_String(Keyboard::Key k) {
 	case Keyboard::Key::Return: s = "Enter"; break;
 	case Keyboard::Key::BackSpace: s = "Retroceso"; break;
 	case Keyboard::Key::Tab: s = "Tab"; break;
-	case Keyboard::Key::PageUp: s = "Pág ar"; break;
-	case Keyboard::Key::PageDown: s = "Pág ab"; break;
+	case Keyboard::Key::PageUp: s = "Pg ar"; break;
+	case Keyboard::Key::PageDown: s = "Pg ab"; break;
 	case Keyboard::Key::End: s = "Fin"; break;
 	case Keyboard::Key::Home: s = "Inicio"; break;
 	case Keyboard::Key::Insert: s = "Insert"; break;

--- a/src/Menu_Inicio.cpp
+++ b/src/Menu_Inicio.cpp
@@ -5,6 +5,7 @@
 #include "Fighting_Escena.h"
 #include "Seleccion_De_Personaje_Escena.h"
 #include "Menu_options.h"
+#include "Assets.h"
 
 
 using namespace std;
@@ -12,8 +13,8 @@ using namespace sf;
 
 Menu_Inicio::Menu_Inicio(){
 	cantidad_de_imagenes=3;
-	for(int i=0;i<cantidad_de_imagenes;i++)  { 
-		menu_textura[i].loadFromFile("Menu_"+to_string(i)+".png");
+        for(int i=0;i<cantidad_de_imagenes;i++)  {
+                menu_textura[i].loadFromFile(asset("sprites/Menu_"+to_string(i)+".png"));
 		menu_sprite[i].setTexture(menu_textura[i]);
 		menu_sprite[i].setPosition(700,i+200);
 	};

--- a/src/Menu_Pause.cpp
+++ b/src/Menu_Pause.cpp
@@ -3,11 +3,12 @@
 #include "Fighting_Escena.h"
 #include "Pantalla_principal.h"
 #include "Seleccion_De_Personaje_Escena.h"
+#include "Assets.h"
 
 Menu_Pause::Menu_Pause():booleano_nulo(nullptr){
 	cantidad_de_imagenes=2;
-	for(int i=0;i<cantidad_de_imagenes;i++)  { 
-		menu_textura[i].loadFromFile("Menu_Pause_"+to_string(i)+".png");
+        for(int i=0;i<cantidad_de_imagenes;i++)  {
+                menu_textura[i].loadFromFile(asset("sprites/Menu_Pause_"+to_string(i)+".png"));
 		menu_sprite[i].setTexture(menu_textura[i]);
 		menu_sprite[i].setPosition(700,i+350);
 	};

--- a/src/Menu_options.cpp
+++ b/src/Menu_options.cpp
@@ -7,6 +7,7 @@
 #include "Pantalla_principal.h"
 #include "Menu_Inicio.h"
 #include "Menu_Controls.h"
+#include "Assets.h"
 
 using namespace std;
 using namespace sf;
@@ -14,13 +15,13 @@ using namespace sf;
 Menu_options::Menu_options() {
 	cantidad_de_imagenes=2;
 	for(int i=0;i<cantidad_de_imagenes;i++)  { 
-		menu_textura[i].loadFromFile("Menu_options_"+to_string(i)+".png");
+		menu_textura[i].loadFromFile(asset("sprites/Menu_options_"+to_string(i)+".png"));
 		menu_sprite[i].setTexture(menu_textura[i]);
 		menu_sprite[i].setPosition(700,i+200);
 	};
 	menu_sprite_principal=&menu_sprite[0];
 	boton_seleccionado=0;
-	Menu_Background_textura.loadFromFile("Menu_Options_Background.jpg");
+	Menu_Background_textura.loadFromFile(asset("backgrounds/Menu_Options_Background.jpg"));
 	Menu_Background_sprite.setTexture(Menu_Background_textura);
 }
 

--- a/src/Pantalla_principal_background.cpp
+++ b/src/Pantalla_principal_background.cpp
@@ -2,6 +2,7 @@
 #include "InfoJugadores.h"
 #include <string>
 #include <SFML/Graphics/RectangleShape.hpp>
+#include "Assets.h"
 using namespace std;
 using namespace sf;
 
@@ -9,12 +10,12 @@ Pantalla_principal_background::Pantalla_principal_background():rectangulo(Vector
 	//SE SETEAN TODOS LOS SPRITES, TEXTURES, ETC PARA LUEGO DIBUJARLOS EN LA CLASE DRAW//
 	
 	//FONDO DE PANTALLA
-	Pantalla_principal_background_texture.loadFromFile("menu_background.jpg");
+        Pantalla_principal_background_texture.loadFromFile(asset("backgrounds/menu_background.jpg"));
 	Pantalla_principal_background_sprite.setTexture(Pantalla_principal_background_texture);
 	Pantalla_principal_background_sprite.setPosition(0, 0);
 	
 	//HISTORIAL DE JUGADORES
-	m_font.loadFromFile("MKtitle1.ttf");
+        m_font.loadFromFile(asset("fonts/MKtitle1.ttf"));
 	Nombre_Player_1_Text.setFont(m_font);
 	Nombre_Player_1_Text.setPosition(70,10);
 	Nombre_Player_1_Text.setCharacterSize(50);

--- a/src/Personaje_1_escena_fighting.cpp
+++ b/src/Personaje_1_escena_fighting.cpp
@@ -5,6 +5,7 @@
 #include "Controles_Player_1.h"
 #include "Controles_Player_2.h"
 #include <iostream>
+#include "Assets.h"
 using namespace std;
 
 
@@ -12,7 +13,7 @@ Personaje_1_escena_fighting::Personaje_1_escena_fighting(int player_1_o_2,string
 	//Nota:Los personajes cargan un monton de sprites y texturas en distintos vectores y lo que se hace es que a travez de un puntero que se va modificando se va mostrando en cada momento el que corresponda
 	//Inicializacion de sprites y texturas del luchador en posicion "de pie"
 	for(int i=0;i<2;i++) { 
-		Pj_standing_texture[i].loadFromFile(nombre_luchador+"_standing_"+to_string(i)+".png");
+		Pj_standing_texture[i].loadFromFile(asset("sprites/"+nombre_luchador+"_standing_"+to_string(i)+".png"));
 		Pj_standing_sprite[i].setTexture(Pj_standing_texture[i]);
 		Pj_standing_sprite[i].setPosition(480,700);
 		Pj_standing_sprite[i].setScale(5,5);
@@ -34,7 +35,7 @@ Personaje_1_escena_fighting::Personaje_1_escena_fighting(int player_1_o_2,string
 	
 	//Inicializacion de sprites y texturas del luchador en accion "caminando"
 	for(int i=0;i<4;i++) { 
-		Pj_walking_texture[i].loadFromFile(nombre_luchador+"_walk_"+to_string(i)+".png");
+		Pj_walking_texture[i].loadFromFile(asset("sprites/"+nombre_luchador+"_walk_"+to_string(i)+".png"));
 		Pj_walking_sprite[i].setTexture(Pj_walking_texture[i]);
 		Pj_walking_sprite[i].setScale(5,5);
 	}
@@ -42,7 +43,7 @@ Personaje_1_escena_fighting::Personaje_1_escena_fighting(int player_1_o_2,string
 	
 	//Inicializacion de sprites y texturas del luchador en accion "atacando"
 	for(int i=0;i<4;i++) { 
-		Pj_attacking_texture[i].loadFromFile(nombre_luchador+"_attack_"+to_string(i)+".png");
+		Pj_attacking_texture[i].loadFromFile(asset("sprites/"+nombre_luchador+"_attack_"+to_string(i)+".png"));
 		Pj_attacking_sprite[i].setTexture(Pj_attacking_texture[i]);
 		Pj_attacking_sprite[i].setScale(5,5);
 	}
@@ -50,21 +51,21 @@ Personaje_1_escena_fighting::Personaje_1_escena_fighting(int player_1_o_2,string
 	
 	//Inicializacion de sprites y texturas del luchador en accion "saltando"
 	for(int i=0;i<2;i++) { 
-		Pj_jumping_texture[i].loadFromFile(nombre_luchador+"_jump_"+to_string(i)+".png");
+		Pj_jumping_texture[i].loadFromFile(asset("sprites/"+nombre_luchador+"_jump_"+to_string(i)+".png"));
 		Pj_jumping_sprite[i].setTexture(Pj_jumping_texture[i]);
 		Pj_jumping_sprite[i].setScale(5,5);
 	}
 	
 	
 	//Inicializacion de sprites y texturas del luchador en accion "final ganador"
-	Pj_win_texture.loadFromFile(nombre_luchador+"_wins.png");
+	Pj_win_texture.loadFromFile(asset("sprites/"+nombre_luchador+"_wins.png"));
 	Pj_win_sprite.setTexture(Pj_win_texture);
 	Pj_win_sprite.setScale(5,5);
 	
 	
 	//Inicializacion de sprites y texturas del luchador en accion "final perdedor"	
 	for(int i=0;i<2;i++) { 
-		Pj_losing_texture[i].loadFromFile(nombre_luchador+"_losing_"+to_string(i)+".png");
+		Pj_losing_texture[i].loadFromFile(asset("sprites/"+nombre_luchador+"_losing_"+to_string(i)+".png"));
 		Pj_losing_sprite[i].setTexture(Pj_losing_texture[i]);
 		Pj_losing_sprite[i].setScale(5,5);
 		Pj_losing_sprite[i].setOrigin(0,-35);
@@ -73,14 +74,14 @@ Personaje_1_escena_fighting::Personaje_1_escena_fighting(int player_1_o_2,string
 	
 	//Inicializacion de sprites y texturas del luchador en accion "Recibir golpe"	
 	for(int i=0;i<4;i++) { 
-		Pj_get_hit_texture[i].loadFromFile(nombre_luchador+"_get_hit_"+to_string(i)+".png");
+		Pj_get_hit_texture[i].loadFromFile(asset("sprites/"+nombre_luchador+"_get_hit_"+to_string(i)+".png"));
 		Pj_get_hit_sprite[i].setTexture(Pj_get_hit_texture[i]);
 		Pj_get_hit_sprite[i].setScale(5,5);
 	}
 	
 	
 	//Efectos de sonido correspondientes a los pasos
-	footstep_effect_soundbuffer.loadFromFile("footstep_sound_effect.wav");
+	footstep_effect_soundbuffer.loadFromFile(asset("audio/music/footstep_sound_effect.wav"));
 	footstep_effect_sound.setBuffer(footstep_effect_soundbuffer);
 	footstep_effect_sound.setVolume(35);
 }
@@ -180,13 +181,13 @@ void Personaje_1_escena_fighting::m_Ejecutar_Fin_Perdedor(){
 }
 
 void Personaje_1_escena_fighting::m_Determinar_Dentro_Limites(){
-	if(Sprite_Principal->getPosition().x>1700){//¿Dentro de los limites del lado derecho?
+	if(Sprite_Principal->getPosition().x>1700){//Dentro de los limites del lado derecho?
 		fuera_de_limites_derecha=true;
 	} else {
 		fuera_de_limites_derecha=false;
 	}
 	
-	if(Sprite_Principal->getPosition().x<0){//¿Dentro de los limites del lado izquierdo?
+	if(Sprite_Principal->getPosition().x<0){//Dentro de los limites del lado izquierdo?
 		fuera_de_limites_izquierda=true;
 	} else {
 		fuera_de_limites_izquierda=false;

--- a/src/Presentacion_Round.cpp
+++ b/src/Presentacion_Round.cpp
@@ -4,6 +4,7 @@
 #include <SFML/Audio/SoundBuffer.hpp>
 #include <SFML/Audio/Sound.hpp>
 #include <SFML/Graphics/RenderWindow.hpp>
+#include "Assets.h"
 
 using namespace std;
 using namespace sf;
@@ -11,7 +12,7 @@ using namespace sf;
 Presentacion_Round::Presentacion_Round(int n_round,int p1, int p2) {
 
 	//Inicializacion del texto que indica el numero de round
-	m_font.loadFromFile("MKtitle1.ttf");
+        m_font.loadFromFile(asset("fonts/MKtitle1.ttf"));
 	m_text.setFont(m_font);
 	m_text.setPosition(700,200);
 	m_text.setCharacterSize(200);
@@ -19,7 +20,7 @@ Presentacion_Round::Presentacion_Round(int n_round,int p1, int p2) {
 	m_text.setString("Round "+to_string(n_round));
 	
 	//Inicializacion del "sonido" correspondiente al anuncio del round por el presentador
-	round_announcer_effect_soundbuffer.loadFromFile("Round_"+to_string(n_round)+"_sound_effect.wav");
+        round_announcer_effect_soundbuffer.loadFromFile(asset("audio/music/Round_"+to_string(n_round)+"_sound_effect.wav"));
 	round_announcer_effect_sound.setBuffer(round_announcer_effect_soundbuffer);
 	
 
@@ -33,7 +34,7 @@ Presentacion_Round::Presentacion_Round(int n_round,int p1, int p2) {
 		luchador_p1.setCharacterSize(200);
 		luchador_p1.setColor({255,50,50});
 		luchador_p1.setString("Kratos Wins");
-		wins_effect_soundbuffer_p1.loadFromFile("Kratos_wins_sound_effect.wav");
+                wins_effect_soundbuffer_p1.loadFromFile(asset("audio/music/Kratos_wins_sound_effect.wav"));
 		wins_effect_sound_p1.setBuffer(wins_effect_soundbuffer_p1);
 		break;
 	case 2://Para el codigo de luchador 1 se sabe por la leyenda expresada en la cabezera de la clase "Players_selected" se sabe es "Sub Zero"
@@ -42,7 +43,7 @@ Presentacion_Round::Presentacion_Round(int n_round,int p1, int p2) {
 		luchador_p1.setCharacterSize(200);
 		luchador_p1.setColor({255,50,50});
 		luchador_p1.setString("Sub Zero Wins");
-		wins_effect_soundbuffer_p1.loadFromFile("Sub_Zero_wins_sound_effect.wav");
+                wins_effect_soundbuffer_p1.loadFromFile(asset("audio/music/Sub_Zero_wins_sound_effect.wav"));
 		wins_effect_sound_p1.setBuffer(wins_effect_soundbuffer_p1);
 		break;
 	default:
@@ -57,7 +58,7 @@ Presentacion_Round::Presentacion_Round(int n_round,int p1, int p2) {
 		luchador_p2.setCharacterSize(200);
 		luchador_p2.setColor({255,50,50});
 		luchador_p2.setString("Kratos Wins");
-		wins_effect_soundbuffer_p2.loadFromFile("Kratos_wins_sound_effect.wav");
+                wins_effect_soundbuffer_p2.loadFromFile(asset("audio/music/Kratos_wins_sound_effect.wav"));
 		wins_effect_sound_p2.setBuffer(wins_effect_soundbuffer_p2);
 		break;
 	case 2://Para el codigo de luchador 2 se sabe por la leyenda expresada en la cabezera de la clase "Players_selected" se sabe es "Sub Zero"
@@ -66,7 +67,7 @@ Presentacion_Round::Presentacion_Round(int n_round,int p1, int p2) {
 		luchador_p2.setCharacterSize(200);
 		luchador_p2.setColor({255,50,50});
 		luchador_p2.setString("Sub Zero Wins");
-		wins_effect_soundbuffer_p2.loadFromFile("Sub_Zero_wins_sound_effect.wav");
+                wins_effect_soundbuffer_p2.loadFromFile(asset("audio/music/Sub_Zero_wins_sound_effect.wav"));
 		wins_effect_sound_p2.setBuffer(wins_effect_soundbuffer_p2);
 		break;
 	default:

--- a/src/Seleccion_De_Personaje_Escena.cpp
+++ b/src/Seleccion_De_Personaje_Escena.cpp
@@ -6,6 +6,7 @@
 #include "Fighting_Escena.h"
 #include "Pantalla_principal.h"
 #include "Menu_Seleccion_Personaje.h"
+#include "Assets.h"
 
 #include <iostream>
 using namespace std;
@@ -14,31 +15,31 @@ using namespace sf;
 Seleccion_De_Personaje_Escena::Seleccion_De_Personaje_Escena():battleground("mkbattleground.png") {
 
 	//fotos grandes
-	Personajes_Texturas[0].loadFromFile("Kratos_Seleccion_De_Personaje.png");
-	Personajes_Texturas[1].loadFromFile("Sub_Zero_Seleccion_De_Personaje.png");
+	Personajes_Texturas[0].loadFromFile(asset("sprites/Kratos_Seleccion_De_Personaje.png"));
+	Personajes_Texturas[1].loadFromFile(asset("sprites/Sub_Zero_Seleccion_De_Personaje.png"));
 	Personajes_Sprites[0].setTexture(Personajes_Texturas[0]);
 	Personajes_Sprites[1].setTexture(Personajes_Texturas[1]);
 	
-	//iconos pequeños izquierda
-	Personajes_Seleccion_Texturas_Izquierda[0].loadFromFile("Kratos_Seleccion.png");
-	Personajes_Seleccion_Texturas_Izquierda[1].loadFromFile("Sub_Zero_Seleccion.png");
+	//iconos pequeos izquierda
+	Personajes_Seleccion_Texturas_Izquierda[0].loadFromFile(asset("sprites/Kratos_Seleccion.png"));
+	Personajes_Seleccion_Texturas_Izquierda[1].loadFromFile(asset("sprites/Sub_Zero_Seleccion.png"));
 	Personajes_Seleccion_Sprites_Izquierda[0].setTexture(Personajes_Seleccion_Texturas_Izquierda[0]);
 	Personajes_Seleccion_Sprites_Izquierda[1].setTexture(Personajes_Seleccion_Texturas_Izquierda[1]);
 	
-	//iconos pequeños derecha
-	Personajes_Seleccion_Texturas_Derecha[0].loadFromFile("Kratos_Seleccion.png");
-	Personajes_Seleccion_Texturas_Derecha[1].loadFromFile("Sub_Zero_Seleccion.png");
+	//iconos pequeos derecha
+	Personajes_Seleccion_Texturas_Derecha[0].loadFromFile(asset("sprites/Kratos_Seleccion.png"));
+	Personajes_Seleccion_Texturas_Derecha[1].loadFromFile(asset("sprites/Sub_Zero_Seleccion.png"));
 	Personajes_Seleccion_Sprites_Derecha[0].setTexture(Personajes_Seleccion_Texturas_Derecha[0]);
 	Personajes_Seleccion_Sprites_Derecha[1].setTexture(Personajes_Seleccion_Texturas_Derecha[1]);
 	
 	//Recuadros de seleccion
-	Recuadros_Seleccion_Texturas[0].loadFromFile("Recuadro_Seleccion_p1.png");
-	Recuadros_Seleccion_Texturas[1].loadFromFile("Recuadro_Seleccion_p2.png");
+	Recuadros_Seleccion_Texturas[0].loadFromFile(asset("sprites/Recuadro_Seleccion_p1.png"));
+	Recuadros_Seleccion_Texturas[1].loadFromFile(asset("sprites/Recuadro_Seleccion_p2.png"));
 	Recuadros_Seleccion_Sprites[0].setTexture(Recuadros_Seleccion_Texturas[0]);
 	Recuadros_Seleccion_Sprites[1].setTexture(Recuadros_Seleccion_Texturas[1]);
 	
 	//Cartel
-	m_font.loadFromFile("MKtitle1.ttf");
+	m_font.loadFromFile(asset("fonts/MKtitle1.ttf"));
 	Escape_Text.setFont(m_font);
 	Escape_Text.setPosition(890,1000);
 	Escape_Text.setCharacterSize(30);

--- a/src/Sub_Zero.cpp
+++ b/src/Sub_Zero.cpp
@@ -9,13 +9,14 @@
 #include "Controles_Player_1.h"
 #include <SFML/Graphics/Text.hpp>
 #include <iostream>
+#include "Assets.h"
 using namespace std;
 using namespace sf;
 
 Sub_Zero::Sub_Zero(int player_1_o_2):Personaje_1_escena_fighting(player_1_o_2,"Sub_Zero") { //Aqui recibe como informacion si sera Player_1 o Player_2 
 	//Inicializa la bola de hielo del ataque de sub zero orientada hacia izquierda y derecha
-	for(int i=0;i<2;i++) {
-		Sub_Zero_ice_ball_texture[i].loadFromFile("Sub_Zero_ice_ball_"+to_string(i)+".png");
+        for(int i=0;i<2;i++) {
+                Sub_Zero_ice_ball_texture[i].loadFromFile(asset("sprites/Sub_Zero_ice_ball_"+to_string(i)+".png"));
 		Sub_Zero_ice_ball_sprite[i].setTexture(Sub_Zero_ice_ball_texture[i]);
 		Sub_Zero_ice_ball_sprite[i].setScale(5,5);
 	}
@@ -23,11 +24,11 @@ Sub_Zero::Sub_Zero(int player_1_o_2):Personaje_1_escena_fighting(player_1_o_2,"S
 	Sub_Zero_pointer_ice_ball_sprite=&Sub_Zero_ice_ball_sprite[0];
 	
 	//Sonido
-	attacking_effect_soundbuffer.loadFromFile("Sub_Zero_attack_sound_effect.wav");
+        attacking_effect_soundbuffer.loadFromFile(asset("audio/music/Sub_Zero_attack_sound_effect.wav"));
 	attacking_effect_sound.setBuffer(attacking_effect_soundbuffer);
-	jumping_effect_soundbuffer.loadFromFile("Sub_Zero_jumping_sound_effect.wav");
+        jumping_effect_soundbuffer.loadFromFile(asset("audio/music/Sub_Zero_jumping_sound_effect.wav"));
 	jumping_effect_sound.setBuffer(jumping_effect_soundbuffer);
-	get_hit_effect_soundbuffer.loadFromFile("Sub_Zero_get_hit_sound_effect.wav");
+        get_hit_effect_soundbuffer.loadFromFile(asset("audio/music/Sub_Zero_get_hit_sound_effect.wav"));
 	get_hit_effect_sound.setBuffer(get_hit_effect_soundbuffer);
 
 	


### PR DESCRIPTION
## Summary
- include `Assets.h` where resources are loaded and wrap all texture, font, music and sound paths with the `asset(...)` helper
- normalize fighter resource lookups (including Kratos and Sub-Zero audio and sprite loads) and document the Kratos sprite casing issue
- update menus, HUD and selection scenes to load assets from the copied `assets/` tree via the helper

## Testing
- `cmake -S . -B build` *(fails: SFML package not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d4b175af58832bb0792a15140057bc