### PR TITLE
Normalize data file access under assets/data

### DIFF
--- a/include/FileIO.h
+++ b/include/FileIO.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#include <filesystem>
+#include <fstream>
+#include <string>
+
+#include "Assets.h"
+
+namespace FileIO {
+inline std::filesystem::path data_path(const std::string& name) {
+        return std::filesystem::path(asset("data/")) / name;
+}
+
+inline void ensure_parent_exists(const std::filesystem::path& p) {
+        std::error_code ec;
+        std::filesystem::create_directories(p.parent_path(), ec);
+}
+
+inline void touch_if_missing(const std::filesystem::path& p, std::ios::openmode mode = std::ios::binary) {
+        if (!std::filesystem::exists(p)) {
+                ensure_parent_exists(p);
+                std::ofstream o(p, (mode | std::ios::out) & ~std::ios::ate);
+        }
+}
+
+inline std::ifstream open_ifstream_or_create(const std::string& name, std::ios::openmode mode = std::ios::binary) {
+        auto p = data_path(name);
+        touch_if_missing(p, mode);
+        std::ifstream in(p, mode);
+        return in;
+}
+
+inline void open_fstream_rw_or_create(const std::string& name, std::fstream& fs, std::ios::openmode mode) {
+        auto p = data_path(name);
+        touch_if_missing(p, std::ios::binary);
+        fs.open(p, mode);
+        if (!fs) {
+                fs.clear();
+                std::ofstream o(p, std::ios::binary | std::ios::trunc);
+                fs.open(p, mode);
+        }
+}
+
+inline std::ofstream open_ofstream_trunc(const std::string& name, std::ios::openmode mode = std::ios::binary | std::ios::trunc) {
+        auto p = data_path(name);
+        ensure_parent_exists(p);
+        std::ofstream out(p, mode | std::ios::out);
+        return out;
+}
+} // namespace FileIO

--- a/src/Controles_Player_1.cpp
+++ b/src/Controles_Player_1.cpp
@@ -1,21 +1,55 @@
 #include "Controles_Player_1.h"
+
 #include <SFML/Window/Keyboard.hpp>
 #include <fstream>
+
+#include "FileIO.h"
+
 using namespace std;
 using namespace sf;
 
+namespace {
+void set_default_controls_player1(Keyboard::Key &left, Keyboard::Key &right, Keyboard::Key &jump, Keyboard::Key &attack) {
+        left = Keyboard::Key::A;
+        right = Keyboard::Key::D;
+        jump = Keyboard::Key::Space;
+        attack = Keyboard::Key::S;
+}
+
+void persist_player1_controls(const Keyboard::Key &left, const Keyboard::Key &right, const Keyboard::Key &jump, const Keyboard::Key &attack) {
+        auto out = FileIO::open_ofstream_trunc("Controles_p1.poo", std::ios::binary | std::ios::trunc);
+        if (!out) {
+                return;
+        }
+        out.write(reinterpret_cast<const char*>(&left), sizeof(Keyboard::Key));
+        out.write(reinterpret_cast<const char*>(&right), sizeof(Keyboard::Key));
+        out.write(reinterpret_cast<const char*>(&jump), sizeof(Keyboard::Key));
+        out.write(reinterpret_cast<const char*>(&attack), sizeof(Keyboard::Key));
+}
+} // namespace
+
 Controles_Player_1::Controles_Player_1(){
-	ifstream archi("Controles_p1.poo",ios::binary);
-	archi.read(reinterpret_cast<char*>(&Caminar_Izquierda),sizeof(Keyboard::Key));
-	archi.read(reinterpret_cast<char*>(&Caminar_Derecha),sizeof(Keyboard::Key));
-	archi.read(reinterpret_cast<char*>(&Saltar),sizeof(Keyboard::Key));
-	archi.read(reinterpret_cast<char*>(&Atacar),sizeof(Keyboard::Key));
-	archi.close();
+        auto archi = FileIO::open_ifstream_or_create("Controles_p1.poo", std::ios::binary);
+        if (!archi || archi.peek() == std::ifstream::traits_type::eof()) {
+                set_default_controls_player1(Caminar_Izquierda, Caminar_Derecha, Saltar, Atacar);
+                persist_player1_controls(Caminar_Izquierda, Caminar_Derecha, Saltar, Atacar);
+                return;
+        }
+
+        archi.read(reinterpret_cast<char*>(&Caminar_Izquierda),sizeof(Keyboard::Key));
+        archi.read(reinterpret_cast<char*>(&Caminar_Derecha),sizeof(Keyboard::Key));
+        archi.read(reinterpret_cast<char*>(&Saltar),sizeof(Keyboard::Key));
+        archi.read(reinterpret_cast<char*>(&Atacar),sizeof(Keyboard::Key));
+
+        if (!archi) {
+                set_default_controls_player1(Caminar_Izquierda, Caminar_Derecha, Saltar, Atacar);
+                persist_player1_controls(Caminar_Izquierda, Caminar_Derecha, Saltar, Atacar);
+        }
 }
 
 
 
-	
+
 Controles_Player_1::~Controles_Player_1(){
-	
+
 }

--- a/src/Controles_Player_2.cpp
+++ b/src/Controles_Player_2.cpp
@@ -1,20 +1,53 @@
 #include "Controles_Player_2.h"
-#include <SFML/Window/Keyboard.hpp>
 
+#include <SFML/Window/Keyboard.hpp>
 #include <fstream>
+
+#include "FileIO.h"
+
 using namespace std;
 using namespace sf;
 
+namespace {
+void set_default_controls_player2(Keyboard::Key &left, Keyboard::Key &right, Keyboard::Key &jump, Keyboard::Key &attack) {
+        left = Keyboard::Key::Left;
+        right = Keyboard::Key::Right;
+        jump = Keyboard::Key::Numpad4;
+        attack = Keyboard::Key::Numpad8;
+}
+
+void persist_player2_controls(const Keyboard::Key &left, const Keyboard::Key &right, const Keyboard::Key &jump, const Keyboard::Key &attack) {
+        auto out = FileIO::open_ofstream_trunc("Controles_p2.poo", std::ios::binary | std::ios::trunc);
+        if (!out) {
+                return;
+        }
+        out.write(reinterpret_cast<const char*>(&left), sizeof(Keyboard::Key));
+        out.write(reinterpret_cast<const char*>(&right), sizeof(Keyboard::Key));
+        out.write(reinterpret_cast<const char*>(&jump), sizeof(Keyboard::Key));
+        out.write(reinterpret_cast<const char*>(&attack), sizeof(Keyboard::Key));
+}
+} // namespace
+
 Controles_Player_2::Controles_Player_2() {
-	ifstream archi("Controles_p2.poo",ios::binary);
-	archi.read(reinterpret_cast<char*>(&Caminar_Izquierda),sizeof(Keyboard::Key));
-	archi.read(reinterpret_cast<char*>(&Caminar_Derecha),sizeof(Keyboard::Key));
-	archi.read(reinterpret_cast<char*>(&Saltar),sizeof(Keyboard::Key));
-	archi.read(reinterpret_cast<char*>(&Atacar),sizeof(Keyboard::Key));
-	archi.close();
+        auto archi = FileIO::open_ifstream_or_create("Controles_p2.poo", std::ios::binary);
+        if (!archi || archi.peek() == std::ifstream::traits_type::eof()) {
+                set_default_controls_player2(Caminar_Izquierda, Caminar_Derecha, Saltar, Atacar);
+                persist_player2_controls(Caminar_Izquierda, Caminar_Derecha, Saltar, Atacar);
+                return;
+        }
+
+        archi.read(reinterpret_cast<char*>(&Caminar_Izquierda),sizeof(Keyboard::Key));
+        archi.read(reinterpret_cast<char*>(&Caminar_Derecha),sizeof(Keyboard::Key));
+        archi.read(reinterpret_cast<char*>(&Saltar),sizeof(Keyboard::Key));
+        archi.read(reinterpret_cast<char*>(&Atacar),sizeof(Keyboard::Key));
+
+        if (!archi) {
+                set_default_controls_player2(Caminar_Izquierda, Caminar_Derecha, Saltar, Atacar);
+                persist_player2_controls(Caminar_Izquierda, Caminar_Derecha, Saltar, Atacar);
+        }
 }
 
 
 Controles_Player_2::~Controles_Player_2() {
-	
+
 }

--- a/src/InfoJugadores.cpp
+++ b/src/InfoJugadores.cpp
@@ -1,160 +1,198 @@
 #include "InfoJugadores.h"
+
 #include <string>
 #include <fstream>
 #include <SFML/Graphics/RenderWindow.hpp>
 #include <SFML/Graphics/Font.hpp>
 #include <iostream>
 #include <cstring>
+
+#include "FileIO.h"
+
 using namespace std;
 using namespace sf;
 
 struct Historial{//Este struct es el que se guarda en el binario que almacena los historicos
-	char Nombre[20];//Se utiliza este tipo de dato debido al problema que suponen los strings en los binarios
-	int ganadas, perdidas;
+        char Nombre[20];//Se utiliza este tipo de dato debido al problema que suponen los strings en los binarios
+        int ganadas, perdidas;
 };
 
 
-	
-	
+
+
 InfoJugadores::InfoJugadores() {
-	Actualizar_Nombres();
+        Actualizar_Nombres();
 }
 
 
 void InfoJugadores::Actualizar_Nombres(){
-	//Se abre el archivo de texto que contiene los nombres ingresados por los jugadores, se los lee y almacena
-	ifstream archi("InfoPublicaJugadores.txt");
-	getline(archi,Nombre_Player_1);
-	archi.ignore(0, '\n');
-	getline(archi,Nombre_Player_1);
-	archi.ignore(0, '\n');
-	
-	getline(archi,Nombre_Player_2);
-	archi.ignore(0, '\n');
-	getline(archi,Nombre_Player_2);
-	archi.ignore(0, '\n');
+        //Se abre el archivo de texto que contiene los nombres ingresados por los jugadores, se los lee y almacena
+        constexpr const char* default_player_1 = "Player 1";
+        constexpr const char* default_player_2 = "Player 2";
+
+        auto persist_defaults = [&](const string& name1, const string& name2) {
+                auto out = FileIO::open_ofstream_trunc("InfoPublicaJugadores.txt", std::ios::out | std::ios::trunc);
+                if (!out) {
+                        return;
+                }
+                out << "Nombre Player 1:" << '\n';
+                out << name1 << '\n';
+                out << "Nombre Player 2:" << '\n';
+                out << name2 << '\n';
+        };
+
+        auto archi = FileIO::open_ifstream_or_create("InfoPublicaJugadores.txt", std::ios::in);
+        if (!archi || archi.peek() == std::ifstream::traits_type::eof()) {
+                Nombre_Player_1 = default_player_1;
+                Nombre_Player_2 = default_player_2;
+                persist_defaults(Nombre_Player_1, Nombre_Player_2);
+                return;
+        }
+
+        string etiqueta;
+        if (!getline(archi, etiqueta) || !getline(archi, Nombre_Player_1) || !getline(archi, etiqueta) || !getline(archi, Nombre_Player_2)) {
+                Nombre_Player_1 = default_player_1;
+                Nombre_Player_2 = default_player_2;
+                persist_defaults(Nombre_Player_1, Nombre_Player_2);
+        }
 }
 
 void InfoJugadores::Actualizar_Historial_Post_Fight(int Ganador){ //Si le llega 1 gano player 1 y si le llega 2 gano el player 2
-	//Se abre el archivo binario que contiene los historicos
-	fstream archi("Historial.poo",ios::binary|ios::out|ios::in|ios::ate);
-	int Tamanio_Historial=archi.tellg()/sizeof(Historial);//Se calcula el tamaño del historial/archivo
-	archi.seekg(0);//Se coloca el "cursor" de lectura en el principio del archivo
-	Historial m_Historial;//Se declara una variable auxiliar para oficiar la lectura del archivo
-	
-	for(int i=0;i<Tamanio_Historial;i++){ 
-		archi.read(reinterpret_cast<char*>(&m_Historial), sizeof(Historial));
-		string aux(m_Historial.Nombre);
-		if(Ganador==1){
-			if(aux==Nombre_Player_1){
-				m_Historial.ganadas=m_Historial.ganadas+1;
-				archi.seekp(i*sizeof(Historial));
-				archi.write(reinterpret_cast<char*>(&m_Historial), sizeof(Historial));
-				archi.seekg((i+1)*sizeof(Historial));
-			} else {
-				if(aux==Nombre_Player_2){
-					m_Historial.perdidas=m_Historial.perdidas+1;
-					archi.seekp(i*sizeof(Historial));
-					archi.write(reinterpret_cast<char*>(&m_Historial), sizeof(Historial));
-					archi.seekg((i+1)*sizeof(Historial));
-				}
-			}	
-		} else {
-			if(aux==Nombre_Player_2){
-				m_Historial.ganadas=m_Historial.ganadas+1;
-				archi.seekp(i*sizeof(Historial));
-				archi.write(reinterpret_cast<char*>(&m_Historial), sizeof(Historial));
-				archi.seekg((i+1)*sizeof(Historial));
-			} else {
-				if(aux==Nombre_Player_1){
-					m_Historial.perdidas=m_Historial.perdidas+1;
-					archi.seekp(i*sizeof(Historial));
-					archi.write(reinterpret_cast<char*>(&m_Historial), sizeof(Historial));
-					archi.seekg((i+1)*sizeof(Historial));
-				}
-			}	
-		}
-	}	
+        //Se abre el archivo binario que contiene los historicos
+        fstream archi;
+        FileIO::open_fstream_rw_or_create("Historial.poo", archi, ios::binary|ios::out|ios::in|ios::ate);
+        if (!archi) {
+                return;
+        }
+        streampos pos = archi.tellg();//Se calcula el tamao del historial/archivo
+        if (pos < 0) {
+                pos = 0;
+        }
+        int Tamanio_Historial=static_cast<int>(pos/sizeof(Historial));//Se calcula el tamao del historial/archivo
+        archi.seekg(0);//Se coloca el "cursor" de lectura en el principio del archivo
+        Historial m_Historial;//Se declara una variable auxiliar para oficiar la lectura del archivo
+
+        for(int i=0;i<Tamanio_Historial;i++){
+                archi.read(reinterpret_cast<char*>(&m_Historial), sizeof(Historial));
+                string aux(m_Historial.Nombre);
+                if(Ganador==1){
+                        if(aux==Nombre_Player_1){
+                                m_Historial.ganadas=m_Historial.ganadas+1;
+                                archi.seekp(i*sizeof(Historial));
+                                archi.write(reinterpret_cast<char*>(&m_Historial), sizeof(Historial));
+                                archi.seekg((i+1)*sizeof(Historial));
+                        } else {
+                                if(aux==Nombre_Player_2){
+                                        m_Historial.perdidas=m_Historial.perdidas+1;
+                                        archi.seekp(i*sizeof(Historial));
+                                        archi.write(reinterpret_cast<char*>(&m_Historial), sizeof(Historial));
+                                        archi.seekg((i+1)*sizeof(Historial));
+                                }
+                        }
+                } else {
+                        if(aux==Nombre_Player_2){
+                                m_Historial.ganadas=m_Historial.ganadas+1;
+                                archi.seekp(i*sizeof(Historial));
+                                archi.write(reinterpret_cast<char*>(&m_Historial), sizeof(Historial));
+                                archi.seekg((i+1)*sizeof(Historial));
+                        } else {
+                                if(aux==Nombre_Player_1){
+                                        m_Historial.perdidas=m_Historial.perdidas+1;
+                                        archi.seekp(i*sizeof(Historial));
+                                        archi.write(reinterpret_cast<char*>(&m_Historial), sizeof(Historial));
+                                        archi.seekg((i+1)*sizeof(Historial));
+                                }
+                        }
+                }
+        }
 }
 
 void InfoJugadores::Obtener_Historial_Jugadores() {
-	//Se abre el archivo binario que contiene los historicos
-	fstream archi("Historial.poo",ios::binary|ios::in|ios::out|ios::ate);
-	int Tamanio_Historial=archi.tellg()/sizeof(Historial);//Se calcula el tamaño del historial/archivo
-	archi.seekg(0);//Se coloca el "cursor" de lectura en el principio del archivo
-	Historial m_Historial;//Se declara una variable auxiliar para oficiar la lectura del archivo
-	
-	bool Player_1_Contabilizado=false, Player_2_Contabilizado=false;
-	for(int i=0;i<Tamanio_Historial;i++){ 
-		archi.read(reinterpret_cast<char*>(&m_Historial), sizeof(Historial));
-		string aux(m_Historial.Nombre);
-		if(aux==Nombre_Player_1){
-			Ganadas_Player_1=m_Historial.ganadas;
-			Perdidas_Player_1=m_Historial.perdidas;
-			Player_1_Contabilizado=true;
-		}
-		if(aux==Nombre_Player_2){
-			Ganadas_Player_2=m_Historial.ganadas;
-			Perdidas_Player_2=m_Historial.perdidas;
-			Player_2_Contabilizado=true;
-		}
-	};
-	
-	
-	if(Player_1_Contabilizado==false){//Si el player_1 no fue contabilizado, es decir es su primera vez jugando, debera ser agregado al historico
-		strcpy(m_Historial.Nombre,Nombre_Player_1.c_str());
-		m_Historial.ganadas=0;
-		m_Historial.perdidas=0;
-		Ganadas_Player_1=0;
-		Perdidas_Player_1=0;
-		archi.seekp(Tamanio_Historial*sizeof(Historial));
-		archi.write(reinterpret_cast<char*>(&m_Historial),sizeof(Historial));
-	}
-	if(Player_2_Contabilizado==false){//Si el player_1 no fue contabilizado, es decir es su primera vez jugando, debera ser agregado al historico
-		strcpy(m_Historial.Nombre,Nombre_Player_2.c_str());
-		m_Historial.ganadas=0;
-		m_Historial.perdidas=0;
-		Ganadas_Player_2=0;
-		Perdidas_Player_2=0;
-		cout << Perdidas_Player_2;
-		archi.seekp(Tamanio_Historial*sizeof(Historial));
-		archi.write(reinterpret_cast<char*>(&m_Historial),sizeof(Historial));
-	}
-	
-	
-}	
+        //Se abre el archivo binario que contiene los historicos
+        fstream archi;
+        FileIO::open_fstream_rw_or_create("Historial.poo", archi, ios::binary|ios::in|ios::out|ios::ate);
+        if (!archi) {
+                return;
+        }
+        streampos pos = archi.tellg();//Se calcula el tamao del historial/archivo
+        if (pos < 0) {
+                pos = 0;
+        }
+        int Tamanio_Historial=static_cast<int>(pos/sizeof(Historial));//Se calcula el tamao del historial/archivo
+        archi.seekg(0);//Se coloca el "cursor" de lectura en el principio del archivo
+        Historial m_Historial;//Se declara una variable auxiliar para oficiar la lectura del archivo
+
+        bool Player_1_Contabilizado=false, Player_2_Contabilizado=false;
+        for(int i=0;i<Tamanio_Historial;i++){
+                archi.read(reinterpret_cast<char*>(&m_Historial), sizeof(Historial));
+                string aux(m_Historial.Nombre);
+                if(aux==Nombre_Player_1){
+                        Ganadas_Player_1=m_Historial.ganadas;
+                        Perdidas_Player_1=m_Historial.perdidas;
+                        Player_1_Contabilizado=true;
+                }
+                if(aux==Nombre_Player_2){
+                        Ganadas_Player_2=m_Historial.ganadas;
+                        Perdidas_Player_2=m_Historial.perdidas;
+                        Player_2_Contabilizado=true;
+                }
+        };
+
+
+        if(Player_1_Contabilizado==false){//Si el player_1 no fue contabilizado, es decir es su primera vez jugando, debera ser agregado al historico
+                strcpy(m_Historial.Nombre,Nombre_Player_1.c_str());
+                m_Historial.ganadas=0;
+                m_Historial.perdidas=0;
+                Ganadas_Player_1=0;
+                Perdidas_Player_1=0;
+                archi.seekp(Tamanio_Historial*sizeof(Historial));
+                archi.write(reinterpret_cast<char*>(&m_Historial),sizeof(Historial));
+        }
+        if(Player_2_Contabilizado==false){//Si el player_1 no fue contabilizado, es decir es su primera vez jugando, debera ser agregado al historico
+                strcpy(m_Historial.Nombre,Nombre_Player_2.c_str());
+                m_Historial.ganadas=0;
+                m_Historial.perdidas=0;
+                Ganadas_Player_2=0;
+                Perdidas_Player_2=0;
+                cout << Perdidas_Player_2;
+                archi.seekp(Tamanio_Historial*sizeof(Historial));
+                archi.write(reinterpret_cast<char*>(&m_Historial),sizeof(Historial));
+        }
+
+
+}
 
 string InfoJugadores::Ver_Nombre_Player_1(){
-	Actualizar_Nombres();
-	return Nombre_Player_1;
+        Actualizar_Nombres();
+        return Nombre_Player_1;
 }
 
 int InfoJugadores::Ver_Ganadas_Player_1(){
-	Obtener_Historial_Jugadores();
-	return Ganadas_Player_1;
+        Obtener_Historial_Jugadores();
+        return Ganadas_Player_1;
 }
 
 int InfoJugadores::Ver_Perdidas_Player_1(){
-	Obtener_Historial_Jugadores();
-	return Perdidas_Player_1;
+        Obtener_Historial_Jugadores();
+        return Perdidas_Player_1;
 }
 
 string InfoJugadores::Ver_Nombre_Player_2(){
-	Actualizar_Nombres();
-	return Nombre_Player_2;
+        Actualizar_Nombres();
+        return Nombre_Player_2;
 }
 
 int InfoJugadores::Ver_Ganadas_Player_2(){
-	Obtener_Historial_Jugadores();
-	return Ganadas_Player_2;
+        Obtener_Historial_Jugadores();
+        return Ganadas_Player_2;
 }
 
 int InfoJugadores::Ver_Perdidas_Player_2(){
-	Obtener_Historial_Jugadores();
-	return Perdidas_Player_2;
+        Obtener_Historial_Jugadores();
+        return Perdidas_Player_2;
 }
 
 InfoJugadores::~InfoJugadores() {
-	
-	
+
+
 }

--- a/src/Menu_Controls.cpp
+++ b/src/Menu_Controls.cpp
@@ -9,6 +9,7 @@
 #include <SFML/System/Vector2.hpp>
 #include <string>
 #include "Assets.h"
+#include "FileIO.h"
 using namespace std;
 
 
@@ -254,35 +255,71 @@ void Menu_Controls::m_Cambiar_Tecla(Juego &j, Keyboard::Key &k){
 }
 
 void Menu_Controls::m_Guardar_Cambios(){
-	ofstream archi("Controles_p1.poo",ios::binary);
-	archi.write(reinterpret_cast<char*>(&Caminar_Izquierda_p1),sizeof(Keyboard::Key));
-	archi.write(reinterpret_cast<char*>(&Caminar_Derecha_p1),sizeof(Keyboard::Key));
-	archi.write(reinterpret_cast<char*>(&Saltar_p1),sizeof(Keyboard::Key));
-	archi.write(reinterpret_cast<char*>(&Atacar_p1),sizeof(Keyboard::Key));
-	archi.close();
-	
-	ofstream archiv("Controles_p2.poo",ios::binary);
-	archiv.write(reinterpret_cast<char*>(&Caminar_Izquierda_p2),sizeof(Keyboard::Key));
-	archiv.write(reinterpret_cast<char*>(&Caminar_Derecha_p2),sizeof(Keyboard::Key));
-	archiv.write(reinterpret_cast<char*>(&Saltar_p2),sizeof(Keyboard::Key));
-	archiv.write(reinterpret_cast<char*>(&Atacar_p2),sizeof(Keyboard::Key));
-	archiv.close();
+        auto archi = FileIO::open_ofstream_trunc("Controles_p1.poo", std::ios::binary | std::ios::trunc);
+        if (archi) {
+                archi.write(reinterpret_cast<char*>(&Caminar_Izquierda_p1),sizeof(Keyboard::Key));
+                archi.write(reinterpret_cast<char*>(&Caminar_Derecha_p1),sizeof(Keyboard::Key));
+                archi.write(reinterpret_cast<char*>(&Saltar_p1),sizeof(Keyboard::Key));
+                archi.write(reinterpret_cast<char*>(&Atacar_p1),sizeof(Keyboard::Key));
+        }
+
+        auto archiv = FileIO::open_ofstream_trunc("Controles_p2.poo", std::ios::binary | std::ios::trunc);
+        if (archiv) {
+                archiv.write(reinterpret_cast<char*>(&Caminar_Izquierda_p2),sizeof(Keyboard::Key));
+                archiv.write(reinterpret_cast<char*>(&Caminar_Derecha_p2),sizeof(Keyboard::Key));
+                archiv.write(reinterpret_cast<char*>(&Saltar_p2),sizeof(Keyboard::Key));
+                archiv.write(reinterpret_cast<char*>(&Atacar_p2),sizeof(Keyboard::Key));
+        }
 }
 
 void Menu_Controls::m_Leer_Controles(){
-	ifstream archi("Controles_p1.poo",ios::binary);
-	archi.read(reinterpret_cast<char*>(&Caminar_Izquierda_p1),sizeof(Keyboard::Key));
-	archi.read(reinterpret_cast<char*>(&Caminar_Derecha_p1),sizeof(Keyboard::Key));
-	archi.read(reinterpret_cast<char*>(&Saltar_p1),sizeof(Keyboard::Key));
-	archi.read(reinterpret_cast<char*>(&Atacar_p1),sizeof(Keyboard::Key));
-	archi.close();
-	
-	ifstream archiv("Controles_p2.poo",ios::binary);
-	archiv.read(reinterpret_cast<char*>(&Caminar_Izquierda_p2),sizeof(Keyboard::Key));
-	archiv.read(reinterpret_cast<char*>(&Caminar_Derecha_p2),sizeof(Keyboard::Key));
-	archiv.read(reinterpret_cast<char*>(&Saltar_p2),sizeof(Keyboard::Key));
-	archiv.read(reinterpret_cast<char*>(&Atacar_p2),sizeof(Keyboard::Key));
-	archiv.close();
+        bool wrote_defaults = false;
+
+        auto set_defaults_p1 = [&]() {
+                Caminar_Izquierda_p1 = Keyboard::Key::A;
+                Caminar_Derecha_p1 = Keyboard::Key::D;
+                Saltar_p1 = Keyboard::Key::Space;
+                Atacar_p1 = Keyboard::Key::S;
+                wrote_defaults = true;
+        };
+
+        auto archi = FileIO::open_ifstream_or_create("Controles_p1.poo", std::ios::binary);
+        if (!archi || archi.peek() == std::ifstream::traits_type::eof()) {
+                set_defaults_p1();
+        } else {
+                archi.read(reinterpret_cast<char*>(&Caminar_Izquierda_p1),sizeof(Keyboard::Key));
+                archi.read(reinterpret_cast<char*>(&Caminar_Derecha_p1),sizeof(Keyboard::Key));
+                archi.read(reinterpret_cast<char*>(&Saltar_p1),sizeof(Keyboard::Key));
+                archi.read(reinterpret_cast<char*>(&Atacar_p1),sizeof(Keyboard::Key));
+                if (!archi) {
+                        set_defaults_p1();
+                }
+        }
+
+        auto set_defaults_p2 = [&]() {
+                Caminar_Izquierda_p2 = Keyboard::Key::Left;
+                Caminar_Derecha_p2 = Keyboard::Key::Right;
+                Saltar_p2 = Keyboard::Key::Numpad4;
+                Atacar_p2 = Keyboard::Key::Numpad8;
+                wrote_defaults = true;
+        };
+
+        auto archiv = FileIO::open_ifstream_or_create("Controles_p2.poo", std::ios::binary);
+        if (!archiv || archiv.peek() == std::ifstream::traits_type::eof()) {
+                set_defaults_p2();
+        } else {
+                archiv.read(reinterpret_cast<char*>(&Caminar_Izquierda_p2),sizeof(Keyboard::Key));
+                archiv.read(reinterpret_cast<char*>(&Caminar_Derecha_p2),sizeof(Keyboard::Key));
+                archiv.read(reinterpret_cast<char*>(&Saltar_p2),sizeof(Keyboard::Key));
+                archiv.read(reinterpret_cast<char*>(&Atacar_p2),sizeof(Keyboard::Key));
+                if (!archiv) {
+                        set_defaults_p2();
+                }
+        }
+
+        if (wrote_defaults) {
+                m_Guardar_Cambios();
+        }
 }
 
 


### PR DESCRIPTION
## Summary
- add FileIO helper utilities to centralize data paths under assets/data
- update control loading/saving code to create files on demand and fall back to default bindings
- harden player info persistence to rebuild missing text/binary files before continuing

## Testing
- cmake -S . -B build *(fails: missing SFML package in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d4b91c79a8832b93395e12465e77a5